### PR TITLE
Using the Job framework in order for the user to continue doing other actions

### DIFF
--- a/bundles/net.tourbook.cloud/src/net/tourbook/cloud/strava/StravaUploader.java
+++ b/bundles/net.tourbook.cloud/src/net/tourbook/cloud/strava/StravaUploader.java
@@ -493,7 +493,6 @@ public class StravaUploader extends TourbookCloudUploader {
          TourLogManager.logTitle(NLS.bind(Messages.Log_UploadToursToStrava_001_Start, numberOfTours));
 
          runnable.schedule();
-         //new ProgressMonitorDialog(Display.getCurrent().getActiveShell()).run(true, true, runnable);
 
          runnable.addJobChangeListener(new JobChangeAdapter() {
             @Override


### PR DESCRIPTION
@wolfgang-ch @telemaxx 

What do you think of converting, when appropriate only, [IRunnableWithProgress ](http://help.eclipse.org/2021-03/topic/org.eclipse.platform.doc.isv/reference/api/org/eclipse/jface/operation/IRunnableWithProgress.html)to [Job ](http://help.eclipse.org/2021-03/topic/org.eclipse.platform.doc.isv/reference/api/org/eclipse/core/runtime/jobs/Job.html)so that the user can continue doing other actions while a job is performed in the background ?
I had this idea when thinking about how Eclipse handles pushing commits and when uploading the commit, it is a job in the bottom and I can continue coding and am not "blocked"
![image](https://user-images.githubusercontent.com/25235665/121091137-10494500-c7d9-11eb-8b34-248ed8c5d978.png)


Here is the example with Strava when sometimes I feel that I don't want to watch the upload but only want to know the final result and in the meantime I can continue use MT

Here is the current behavior where the window blocks the user of doing anything else:
![image](https://user-images.githubusercontent.com/25235665/121090574-5225bb80-c7d8-11eb-9350-b11361ada124.png)


here is what it looks like after this code change. The progress can be displayed but the user can do other actions and is not "blocked":
![image](https://user-images.githubusercontent.com/25235665/121090345-fa875000-c7d7-11eb-9ffb-83848167cc94.png)

In both cases, when the operation is done, the summary will be displayed to the user:
![image](https://user-images.githubusercontent.com/25235665/121090885-c2344180-c7d8-11eb-9217-0d4863bc3f50.png)
