### PR TITLE
[Calendar View] The combo of years now displays the most recent years at the top as it is more likely to be selected than the oldest years

### DIFF
--- a/bundles/net.tourbook/src/net/tourbook/ui/views/calendar/CalendarYearMonthContributionItem.java
+++ b/bundles/net.tourbook/src/net/tourbook/ui/views/calendar/CalendarYearMonthContributionItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2011,2017 Matthias Helmling and Contributors
+ * Copyright (C) 2011, 2022 Matthias Helmling and Contributors
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package net.tourbook.ui.views.calendar;
 
+import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -28,206 +30,188 @@ import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.layout.PixelConverter;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.TraverseEvent;
-import org.eclipse.swt.events.TraverseListener;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
 public class CalendarYearMonthContributionItem extends ControlContribution {
 
-	private static final String	ID			= "net.tourbook.calendar.yearmonthselector";	//$NON-NLS-1$
-	//
-	private final boolean		_isOSX		= UI.IS_OSX;
-	private final boolean		_isLinux	= UI.IS_LINUX;
-	//
-	private ArrayList<Integer>	_allYearValues;
-	//
-	private CalendarGraph		_calendarGraph;
+   private static final String  ID       = "net.tourbook.calendar.yearmonthselector"; //$NON-NLS-1$
+   //
+   private static final boolean _isOSX   = UI.IS_OSX;
+   private static final boolean _isLinux = UI.IS_LINUX;
+   //
+   private ArrayList<Integer>   _allYearValues;
+   //
+   private CalendarGraph        _calendarGraph;
 
-	/*
-	 * UI controls
-	 */
-	private Combo				_comboYear;
-	private Combo				_comboMonth;
+   /*
+    * UI controls
+    */
+   private Combo _comboYear;
+   private Combo _comboMonth;
 
-	protected CalendarYearMonthContributionItem(final CalendarGraph calendarGraph) {
+   protected CalendarYearMonthContributionItem(final CalendarGraph calendarGraph) {
 
-		super(ID);
+      super(ID);
 
-		_calendarGraph = calendarGraph;
-	}
+      _calendarGraph = calendarGraph;
+   }
 
-	protected CalendarYearMonthContributionItem(final String id) {
-		super(id);
-	}
+   protected CalendarYearMonthContributionItem(final String id) {
+      super(id);
+   }
 
-	@Override
-	protected Control createControl(final Composite parent) {
+   @Override
+   protected Control createControl(final Composite parent) {
 
-		final PixelConverter pc = new PixelConverter(parent);
+      final PixelConverter pc = new PixelConverter(parent);
 
-		final Composite container = new Composite(parent, SWT.NONE);
-		GridDataFactory.fillDefaults().grab(true, false).applyTo(container);
-		GridLayoutFactory
-				.fillDefaults()//
-				.numColumns(2)
-				.extendedMargins(0, 10, 0, 0)
-				//				.spacing(0, 0)
-				.applyTo(container);
-		{
-			{
-				/*
-				 * Month
-				 */
+      final Composite container = new Composite(parent, SWT.NONE);
+      GridDataFactory.fillDefaults().grab(true, false).applyTo(container);
+      GridLayoutFactory
+            .fillDefaults()//
+            .numColumns(2)
+            .extendedMargins(0, 10, 0, 0)
+            //				.spacing(0, 0)
+            .applyTo(container);
+      {
+         {
+            /*
+             * Month
+             */
 
-				// combo
-				_comboMonth = new Combo(container, SWT.DROP_DOWN | SWT.READ_ONLY);
-				_comboMonth.setToolTipText(Messages.Calendar_View_Combo_Month_Tooltip);
-				_comboMonth.addSelectionListener(new SelectionAdapter() {
-					@Override
-					public void widgetSelected(final SelectionEvent e) {
-						onSelectDate();
-					}
-				});
-			}
-			{
-				/*
-				 * Year
-				 */
+            // combo
+            _comboMonth = new Combo(container, SWT.DROP_DOWN | SWT.READ_ONLY);
+            _comboMonth.setToolTipText(Messages.Calendar_View_Combo_Month_Tooltip);
+            _comboMonth.addSelectionListener(widgetSelectedAdapter(selectionEvent -> onSelectDate()));
+         }
+         {
+            /*
+             * Year
+             */
 
-				// combo
-				_comboYear = new Combo(container, SWT.DROP_DOWN | SWT.READ_ONLY);
-				_comboYear.setToolTipText(Messages.Calendar_View_Combo_Year_Tooltip);
-				_comboYear.setVisibleItemCount(50);
-				GridDataFactory
-						.fillDefaults()//
-						.hint(pc.convertWidthInCharsToPixels(_isOSX ? 12 : _isLinux ? 12 : 5), SWT.DEFAULT)
-						.applyTo(_comboYear);
+            // combo
+            _comboYear = new Combo(container, SWT.DROP_DOWN | SWT.READ_ONLY);
+            _comboYear.setToolTipText(Messages.Calendar_View_Combo_Year_Tooltip);
+            _comboYear.setVisibleItemCount(50);
+            GridDataFactory
+                  .fillDefaults()//
+                  .hint(pc.convertWidthInCharsToPixels(_isOSX ? 12 : _isLinux ? 12 : 5), SWT.DEFAULT)
+                  .applyTo(_comboYear);
 
-				_comboYear.addSelectionListener(new SelectionAdapter() {
-					@Override
-					public void widgetSelected(final SelectionEvent e) {
-						onSelectDate();
-					}
-				});
+            _comboYear.addSelectionListener(widgetSelectedAdapter(selectionEvent -> onSelectDate()));
 
-				_comboYear.addTraverseListener(new TraverseListener() {
+            _comboYear.addTraverseListener(traverseEvent -> {
+               if (traverseEvent.detail == SWT.TRAVERSE_RETURN) {
+                  onSelectDate();
+               }
+            });
+         }
+      }
 
-					@Override
-					public void keyTraversed(final TraverseEvent e) {
-						if (e.detail == SWT.TRAVERSE_RETURN) {
-							onSelectDate();
-						}
-					}
-				});
-			}
-		}
+      fillMonthComboBox();
+      fillYearComboBox();
 
-		fillMonthComboBox();
-		fillYearComboBox();
+      return container;
 
-		return container;
+   }
 
-	}
+   private void fillMonthComboBox() {
 
-	private void fillMonthComboBox() {
+      LocalDate date = LocalDate.now();
+      final int thisMonth = date.getMonthValue();
+      date = date.withMonth(1);
 
-		LocalDate date = LocalDate.now();
-		final int thisMonth = date.getMonthValue();
-		date = date.withMonth(1);
+      for (int monthIndex = 0; monthIndex < 12; monthIndex++) {
 
-		for (int monthIndex = 0; monthIndex < 12; monthIndex++) {
+         _comboMonth.add(TimeTools.Formatter_Month.format(date));
 
-			_comboMonth.add(TimeTools.Formatter_Month.format(date));
+         date = date.plusMonths(1);
+      }
 
-			date = date.plusMonths(1);
-		}
+      // select this month
+      _comboMonth.select(thisMonth - 1);
 
-		// select this month
-		_comboMonth.select(thisMonth - 1);
+   }
 
-	}
+   private void fillYearComboBox() {
 
-	private void fillYearComboBox() {
+      final int thisYear = LocalDate.now().getYear();
 
-		final int thisYear = LocalDate.now().getYear();
+      _allYearValues = new ArrayList<>();
 
-		_allYearValues = new ArrayList<Integer>();
+      final LocalDateTime firstTourDateTime = CalendarTourDataProvider.getInstance().getFirstTourDateTime();
+      final int firstYear = firstTourDateTime.getYear();
 
-		final LocalDateTime firstTourDateTime = CalendarTourDataProvider.getInstance().getFirstTourDateTime();
-		final int firstYear = firstTourDateTime.getYear();
+      for (int year = thisYear; year >= firstYear; year--) {
 
-		for (int year = firstYear; year <= thisYear; year++) {
+         _comboYear.add(Integer.toString(year));
+         _allYearValues.add(year);
+      }
 
-			_comboYear.add(Integer.toString(year));
-			_allYearValues.add(year);
-		}
+      // select first year
+      _comboYear.select(0);
+   }
 
-		// select last year
-		_comboYear.select(_allYearValues.size() - 1);
-	}
+   private void onSelectDate() {
 
-	private void onSelectDate() {
+      int yearIndex = _comboYear.getSelectionIndex();
+      if (yearIndex < 0) {
+         yearIndex = 0;
+      }
 
-		int yearIndex = _comboYear.getSelectionIndex();
-		if (yearIndex < 0) {
-			yearIndex = 0;
-		}
+      final int selectedYear = _allYearValues.get(yearIndex);
+      final int selectedMonth = _comboMonth.getSelectionIndex() + 1;
 
-		final int selectedYear = _allYearValues.get(yearIndex);
-		final int selectedMonth = _comboMonth.getSelectionIndex() + 1;
+      _calendarGraph.gotoDate(LocalDate.of(selectedYear, selectedMonth, 1), false);
+   }
 
-		_calendarGraph.gotoDate(LocalDate.of(selectedYear, selectedMonth, 1), false);
-	}
+   void setDate(final LocalDate requestedDate, final CalendarProfile calendarProfile) {
 
-	void setDate(final LocalDate requestedDate, final CalendarProfile calendarProfile) {
+      // disable month when year columns are used
+      _comboMonth.setEnabled(
+            !(calendarProfile.isShowYearColumns
+                  && calendarProfile.yearColumnsStart != ColumnStart.CONTINUOUSLY));
 
-		// disable month when year columns are used
-		_comboMonth.setEnabled(
-				!(calendarProfile.isShowYearColumns
-						&& calendarProfile.yearColumnsStart != ColumnStart.CONTINUOUSLY));
+      final int requestedYear = requestedDate.getYear();
 
-		final int requestedYear = requestedDate.getYear();
+      if (requestedYear < _allYearValues.get(_allYearValues.size() - 1)) {
 
-		if (requestedYear < _allYearValues.get(0)) {
+         // year is before available years
 
-			// year is before available years
+         // select first date
+         _comboMonth.select(0);
+         _comboYear.select(0);
 
-			// select first date
-			_comboMonth.select(0);
-			_comboYear.select(0);
+      } else if (requestedYear > _allYearValues.get(0)) {
 
-		} else if (requestedYear > _allYearValues.get(_allYearValues.size() - 1)) {
+         // year is after the available years
 
-			// year is after the available years
+         // select last date
+         _comboMonth.select(11);
+         _comboYear.select(0);
 
-			// select last date
-			_comboMonth.select(11);
-			_comboYear.select(_allYearValues.size() - 1);
+      } else {
 
-		} else {
+         // year is available
 
-			// year is available
+         for (int yearIndex = 0; yearIndex < _allYearValues.size(); yearIndex++) {
 
-			for (int yearIndex = 0; yearIndex < _allYearValues.size(); yearIndex++) {
+            final int currentYear = _allYearValues.get(yearIndex);
 
-				final int currentYear = _allYearValues.get(yearIndex);
+            if (currentYear == requestedYear) {
 
-				if (currentYear == requestedYear) {
+               final int requestedMonth = requestedDate.getMonthValue();
 
-					final int requestedMonth = requestedDate.getMonthValue();
+               _comboMonth.select(requestedMonth - 1);
+               _comboYear.select(yearIndex);
 
-					_comboMonth.select(requestedMonth - 1);
-					_comboYear.select(yearIndex);
+               break;
+            }
+         }
+      }
 
-					break;
-				}
-			}
-		}
-
-	}
+   }
 
 }

--- a/info/release-notes/22.next.0-readme.txt
+++ b/info/release-notes/22.next.0-readme.txt
@@ -36,7 +36,8 @@ New
 Improvements
 ============
 
-* 
+* Calendar View (Frederic)
+ - The combo of years now displays the most recent years at the top as it is more likely to be selected than the oldest years
 
 
 Changes


### PR DESCRIPTION
**Before (I have to go to the bottom of the combo to select last year's 2021):

![image](https://user-images.githubusercontent.com/25235665/155070740-bf1f7b86-72ce-4dcd-b2e4-5c574c891600.png)


After (2021 or any recent year is easily selectable) :**

![image](https://user-images.githubusercontent.com/25235665/155070784-e636c199-f176-494b-ae23-1e947d51b0cc.png)
